### PR TITLE
Bug: new visit wasn’t created.

### DIFF
--- a/library/src/main/java/com/github/instacart/ahoy/Ahoy.java
+++ b/library/src/main/java/com/github/instacart/ahoy/Ahoy.java
@@ -151,7 +151,8 @@ public class Ahoy {
                     return;
                 }
             }
-            updateQueue.add(NewVisitRequest.create(VisitParams.create(visitorToken, null, null)));
+            updateQueue.add(0, NewVisitRequest.create(VisitParams.create(visitorToken, null,
+                    null)));
         }
     }
 

--- a/library/src/main/java/com/github/instacart/ahoy/LifecycleCallbackWrapper.java
+++ b/library/src/main/java/com/github/instacart/ahoy/LifecycleCallbackWrapper.java
@@ -21,7 +21,6 @@ import android.support.annotation.VisibleForTesting;
 
 import com.github.instacart.ahoy.utils.ActivityLifecycleCallbacksStub;
 
-@VisibleForTesting
 public class LifecycleCallbackWrapper extends ActivityLifecycleCallbacksStub {
 
     private Listener mListener;

--- a/tests/src/test/java/com/github/instacart/ahoy/tests/SaveUtmTest.java
+++ b/tests/src/test/java/com/github/instacart/ahoy/tests/SaveUtmTest.java
@@ -124,6 +124,7 @@ public class SaveUtmTest {
 
         when(storage.readVisit(nullable(Visit.class))).thenReturn(Visit.empty());
 
+        final Visit updatedVisit = visit.withUpdatedExtraParams(utmParams);
         delegate = new AhoyDelegate() {
             @Override public String newVisitorToken() {
                 fail();
@@ -137,7 +138,7 @@ public class SaveUtmTest {
 
             @Override public void saveExtras(VisitParams params, AhoyCallback callback) {
                 assertEquals(VisitParams.create(visitorToken, visit, utmParams), params);
-                callback.onSuccess(visit.withUpdatedExtraParams(utmParams));
+                callback.onSuccess(updatedVisit);
             }
         };
         final CountDownLatch latch = new CountDownLatch(2);
@@ -152,6 +153,7 @@ public class SaveUtmTest {
 
         assertTrue(latch.await(2000, TimeUnit.MILLISECONDS));
         verify(storage).saveVisit(visit);
-        assertEquals(ahoy.visit(), visit.withUpdatedExtraParams(utmParams));
+        verify(storage).saveVisit(updatedVisit);
+        assertEquals(ahoy.visit(), updatedVisit);
     }
 }

--- a/tests/src/test/java/com/github/instacart/ahoy/tests/SaveUtmTest.java
+++ b/tests/src/test/java/com/github/instacart/ahoy/tests/SaveUtmTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.nullable;
@@ -110,5 +111,47 @@ public class SaveUtmTest {
         assertTrue(latch.await(2000, TimeUnit.MILLISECONDS));
         verify(storage).saveVisit(visit);
         assertEquals(ahoy.visit(), visit);
+    }
+
+    @Test public void testStoringWithNoVisit() throws Exception {
+
+        final Map<String, Object> utmParams = new ArrayMap<>();
+        utmParams.put(Visit.UTM_CAMPAIGN, "campaign");
+        utmParams.put(Visit.UTM_CONTENT, "content");
+        utmParams.put(Visit.UTM_MEDIUM, "medium");
+        utmParams.put(Visit.UTM_SOURCE, "source");
+        utmParams.put(Visit.UTM_TERM, "term");
+
+        when(storage.readVisit(nullable(Visit.class))).thenReturn(Visit.empty());
+
+        delegate = new AhoyDelegate() {
+            @Override public String newVisitorToken() {
+                fail();
+                return null;
+            }
+
+            @Override public void saveVisit(VisitParams params, AhoyCallback callback) {
+                assertNull(params.visit());
+                callback.onSuccess(visit);
+            }
+
+            @Override public void saveExtras(VisitParams params, AhoyCallback callback) {
+                assertEquals(VisitParams.create(visitorToken, visit, utmParams), params);
+                callback.onSuccess(visit.withUpdatedExtraParams(utmParams));
+            }
+        };
+        final CountDownLatch latch = new CountDownLatch(2);
+        ahoy.init(storage, wrapper, delegate, true);
+        ahoy.addVisitListener(new VisitListener() {
+            @Override public void onVisitUpdated(Visit visit) {
+                latch.countDown();
+            }
+        });
+        wrapper.onActivityCreated(null, null);
+        ahoy.saveExtras(utmParams);
+
+        assertTrue(latch.await(2000, TimeUnit.MILLISECONDS));
+        verify(storage).saveVisit(visit);
+        assertEquals(ahoy.visit(), visit.withUpdatedExtraParams(utmParams));
     }
 }


### PR DESCRIPTION
If `saveExtras` was called w/o pre-existing valid visit, delegate’s `saveExtras` method was called before `saveVisit`. As a result extra params were saved on non-existing visit.
